### PR TITLE
remove: ip from user list

### DIFF
--- a/vrp/modules/admin.lua
+++ b/vrp/modules/admin.lua
@@ -19,7 +19,7 @@ local function ch_list(player,choice)
                 local source = vRP.getUserSource(k)
                 vRP.getUserIdentity(k, function(identity)
                     if source ~= nil then
-                        content = content.."<br />"..k.." => <span class=\"pseudo\">"..vRP.getPlayerName(source).."</span> <span class=\"endpoint\">"..vRP.getPlayerEndpoint(source).."</span>"
+                        content = content.."<br />"..k.." => <span class=\"pseudo\">"..vRP.getPlayerName(source).."</span> <span class=\"endpoint\">"..'REDACATED'.."</span>"
                         if identity then
                             content = content.." <span class=\"name\">"..htmlEntities.encode(identity.firstname).." "..htmlEntities.encode(identity.name).."</span> <span class=\"reg\">"..identity.registration.."</span> <span class=\"phone\">"..identity.phone.."</span>"
                         end


### PR DESCRIPTION
Reduces the risk of IP leaks from vulnerable events from other resources. 

A risk of IP leaks when malicious people get access to permissions from other resources that have no protection to any and group functions they have