### PR TITLE
added drawing markers loop

### DIFF
--- a/vrp/client/map.lua
+++ b/vrp/client/map.lua
@@ -64,6 +64,7 @@ end
 local markers = {}
 local marker_ids = Tools.newIDGenerator()
 local named_markers = {}
+local drawing_markers = {}
 
 -- add a circular marker to the game map
 -- return marker id
@@ -121,6 +122,24 @@ function tvRP.removeNamedMarker(name)
   end
 end
 
+-- markers sort loop
+Citizen.CreateThread(function()
+  while true do
+    Citizen.Wait(1000)
+
+    local px,py,pz = tvRP.getPosition()
+
+    for k,v in pairs(markers) do
+      -- 150 is the min distance wich the markers will be starting to be drawn
+      if GetDistanceBetweenCoords(v.x,v.y,v.z,px,py,pz,true) <= 150.0 then
+        drawing_markers[k] = v
+      else
+        if drawing_markers[k] then drawing_markers[k] = nil end
+      end
+    end
+  end
+end)
+
 -- markers draw loop
 Citizen.CreateThread(function()
   while true do
@@ -128,7 +147,9 @@ Citizen.CreateThread(function()
 
     local px,py,pz = tvRP.getPosition()
 
-    for k,v in pairs(markers) do
+    -- if this loop get filled with too many markers, the clientside
+    -- starts lagging
+    for k,v in pairs(drawing_markers) do
       -- check visibility
       if GetDistanceBetweenCoords(v.x,v.y,v.z,px,py,pz,true) <= v.visible_distance then
         DrawMarker(1,v.x,v.y,v.z,0,0,0,0,0,0,v.sx,v.sy,v.sz,v.r,v.g,v.b,v.a,0,0,0,0)

--- a/vrp/client/map.lua
+++ b/vrp/client/map.lua
@@ -131,7 +131,7 @@ Citizen.CreateThread(function()
 
     for k,v in pairs(markers) do
       -- 150 is the min distance wich the markers will be starting to be drawn
-      if GetDistanceBetweenCoords(v.x,v.y,v.z,px,py,pz,true) <= 150.0 then
+      if #(vector3(v.x,v.y,v.z) - vector3(px,py,pz)) <= 150.0 then
         drawing_markers[k] = v
       else
         if drawing_markers[k] then drawing_markers[k] = nil end
@@ -151,7 +151,7 @@ Citizen.CreateThread(function()
     -- starts lagging
     for k,v in pairs(drawing_markers) do
       -- check visibility
-      if GetDistanceBetweenCoords(v.x,v.y,v.z,px,py,pz,true) <= v.visible_distance then
+      if #(vector3(v.x,v.y,v.z) - vector3(px,py,pz)) <= v.visible_distance then
         DrawMarker(1,v.x,v.y,v.z,0,0,0,0,0,0,v.sx,v.sy,v.sz,v.r,v.g,v.b,v.a,0,0,0,0)
       end
     end


### PR DESCRIPTION
This is a little modification of the current marker drawing system:

If the local markers table get filled with too many markers, the for iter (wich is set to cycle every frame) get filled with too many elements and has some troubles drawing markers without keeping stable performances.

This works but needs some intensive testing (wich i can't do right now). I also made a markers drawing using the gridsystem file developed by deterministic_bubble on the FiveM forum. Let me know if you want a peak on the code.