### PR TITLE
add: ignore query warnings

### DIFF
--- a/ghmattimysql/ghmattimysql-server.js
+++ b/ghmattimysql/ghmattimysql-server.js
@@ -2203,8 +2203,7 @@
             tag = (string = `[${options.tag}]${levelTag}`, `${options.color}${string}${Color.Default}`);
         var string;
         if (tag.includes("WARNING")) {
-            console.log(`${tag} ${msg}`)
-            return;
+            return; // Ignores query warnings.
         }
         if (msg.includes("ECONNREFUSED")) {
             console.log(`^1[vRP GhMattiMySql]^1:^7 The database connection could not be established. Make sure to edit the ghmattimysql/config.json with the correct credentials.`)


### PR DESCRIPTION
- When saving/updating large amounts of data query warnings may pop up. Generally not needed or useful and can be removed.